### PR TITLE
Implement modular AI content generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# AI Content Factory
+
+A minimal Python system to generate social media content with OpenAI GPT and DALL·E 3, with fallback to Fal.ai or Veo.
+
+## Quick Start
+
+1. Install dependencies:
+   ```bash
+   pip install -r ai_content_factory/requirements.txt
+   ```
+2. Set environment variables for API keys:
+   - `OPENAI_API_KEY`
+   - `TELEGRAM_TOKEN`
+   - `TELEGRAM_CHAT_ID`
+   - `FAL_API_KEY` (optional)
+3. Run the FastAPI app:
+   ```bash
+   uvicorn ai_content_factory.main:app --reload
+   ```
+
+Send a POST request to `/generate-content` with JSON:
+```json
+{
+  "prompt": "Write a post about AI",
+  "route": "linkedin",
+  "image_prompt": "robot at desk"
+}
+```
+
+### Video Generation
+
+Use `generate_video(prompt)` to create a short clip via Veo if available.

--- a/ai_content_factory/config.py
+++ b/ai_content_factory/config.py
@@ -1,0 +1,6 @@
+import os
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+FAL_API_KEY = os.getenv("FAL_API_KEY")

--- a/ai_content_factory/image_gen.py
+++ b/ai_content_factory/image_gen.py
@@ -1,0 +1,40 @@
+import requests
+import openai
+from config import OPENAI_API_KEY, FAL_API_KEY
+
+openai.api_key = OPENAI_API_KEY
+
+
+def generate_image(prompt: str) -> str:
+    if OPENAI_API_KEY:
+        try:
+            response = openai.Image.create(
+                prompt=prompt,
+                n=1,
+                size="1024x1024"
+            )
+            return response['data'][0]['url']
+        except Exception:
+            pass
+    if FAL_API_KEY:
+        try:
+            url = "https://api.fal.ai/generate"
+            headers = {"Authorization": f"Bearer {FAL_API_KEY}"}
+            json = {"prompt": prompt}
+            r = requests.post(url, headers=headers, json=json)
+            if r.ok:
+                return r.json().get("url")
+        except requests.RequestException:
+            pass
+    return None
+
+def generate_video(prompt: str) -> str:
+    try:
+        url = "https://api.veo.ai/v3/generate"
+        json = {"prompt": prompt}
+        r = requests.post(url, json=json)
+        if r.ok:
+            return r.json().get("url")
+    except requests.RequestException:
+        pass
+    return None

--- a/ai_content_factory/main.py
+++ b/ai_content_factory/main.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, Request
+from router import route_prompt
+from notifier import send_telegram_message
+from image_gen import generate_image
+
+app = FastAPI()
+
+@app.post("/generate-content")
+async def generate_content(request: Request):
+    data = await request.json()
+    user_prompt = data.get("prompt")
+    route = data.get("route")
+    image_prompt = data.get("image_prompt")
+
+    text_output = route_prompt(user_prompt, route)
+
+    image_url = None
+    if image_prompt:
+        image_url = generate_image(image_prompt)
+
+    send_telegram_message("Content Generated ✅", text_output)
+    return {"content": text_output, "image": image_url}

--- a/ai_content_factory/notifier.py
+++ b/ai_content_factory/notifier.py
@@ -1,0 +1,12 @@
+import requests
+from config import TELEGRAM_TOKEN, TELEGRAM_CHAT_ID
+
+def send_telegram_message(title: str, message: str) -> None:
+    if not (TELEGRAM_TOKEN and TELEGRAM_CHAT_ID):
+        return
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    data = {"chat_id": TELEGRAM_CHAT_ID, "text": f"{title}\n\n{message}"}
+    try:
+        requests.post(url, data=data)
+    except requests.RequestException:
+        pass

--- a/ai_content_factory/prompts/__init__.py
+++ b/ai_content_factory/prompts/__init__.py
@@ -1,0 +1,11 @@
+def load_system_prompt() -> str:
+    with open("ai_content_factory/prompts/system_prompt.md", "r") as f:
+        return f.read()
+
+def load_platform_prompt(platform: str) -> str:
+    path = f"ai_content_factory/prompts/{platform}.md"
+    try:
+        with open(path, "r") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""

--- a/ai_content_factory/prompts/facebook.md
+++ b/ai_content_factory/prompts/facebook.md
@@ -1,0 +1,1 @@
+Template for facebook

--- a/ai_content_factory/prompts/instagram.md
+++ b/ai_content_factory/prompts/instagram.md
@@ -1,0 +1,1 @@
+Template for instagram

--- a/ai_content_factory/prompts/linkedin.md
+++ b/ai_content_factory/prompts/linkedin.md
@@ -1,0 +1,1 @@
+Template for linkedin

--- a/ai_content_factory/prompts/system_prompt.md
+++ b/ai_content_factory/prompts/system_prompt.md
@@ -1,0 +1,1 @@
+You are a helpful assistant generating social media content.

--- a/ai_content_factory/prompts/threads.md
+++ b/ai_content_factory/prompts/threads.md
@@ -1,0 +1,1 @@
+Template for threads

--- a/ai_content_factory/prompts/xtwitter.md
+++ b/ai_content_factory/prompts/xtwitter.md
@@ -1,0 +1,1 @@
+Template for xtwitter

--- a/ai_content_factory/prompts/youtube_short.md
+++ b/ai_content_factory/prompts/youtube_short.md
@@ -1,0 +1,1 @@
+Template for youtube_short

--- a/ai_content_factory/requirements.txt
+++ b/ai_content_factory/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+openai
+requests

--- a/ai_content_factory/router.py
+++ b/ai_content_factory/router.py
@@ -1,0 +1,32 @@
+import openai
+from config import OPENAI_API_KEY
+from prompts import load_system_prompt, load_platform_prompt
+from schemas import PLATFORM_SCHEMAS
+
+openai.api_key = OPENAI_API_KEY
+
+def route_prompt(user_prompt: str, route: str) -> str:
+    system = load_system_prompt()
+    platform_prompt = load_platform_prompt(route)
+    schema = PLATFORM_SCHEMAS.get(route, "")
+
+    prompt = f"""
+{system}
+
+{platform_prompt}
+
+User Prompt: {user_prompt}
+
+JSON Schema:
+{schema}
+"""
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    return response['choices'][0]['message']['content']

--- a/ai_content_factory/schemas.py
+++ b/ai_content_factory/schemas.py
@@ -1,0 +1,21 @@
+PLATFORM_SCHEMAS = {
+    "linkedin": """
+    {
+      \"type\": \"object\",
+      \"properties\": {
+        \"post\": {\"type\": \"string\"},
+        \"call_to_action\": {\"type\": \"string\"}
+      }
+    }
+    """,
+    "xtwitter": """
+    {
+      \"type\": \"object\",
+      \"properties\": {
+        \"post\": {\"type\": \"string\"},
+        \"hashtags\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}}
+      }
+    }
+    """
+    # Add other platforms as needed
+}


### PR DESCRIPTION
## Summary
- add skeleton for `ai_content_factory` package
- implement FastAPI endpoint with Telegram notification
- support DALL·E 3 image generation with Fal.ai fallback
- include basic prompts and schemas
- document usage in new README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866f910c6c8832b8f9a227efe0a2763